### PR TITLE
Simpler typing situation for combine

### DIFF
--- a/epa_regions/__init__.py
+++ b/epa_regions/__init__.py
@@ -221,18 +221,18 @@ def get(
 
     from .load import load
 
-    gdf = load(resolution, version=version)
+    gdf_ne = load(resolution, version=version)
     # NOTE: sov_a3 = 'US1' includes Guam and PR
     # NOTE: iso_a2 is the 2-letter country code
 
-    gdf.columns = gdf.columns.str.lower()
+    gdf_ne.columns = gdf_ne.columns.str.lower()
 
     #
     # States + DC
     #
 
     states = (
-        gdf[["geometry", "name", "admin", "postal"]]
+        gdf_ne[["geometry", "name", "admin", "postal"]]
         .query("admin == 'United States of America'")
         .drop(columns=["admin"])
         .rename(columns={"postal": "abbrev"})
@@ -246,8 +246,8 @@ def get(
         gdf = states
     else:
         other = (
-            gdf.loc[
-                gdf["admin"].isin(_OTHER_ADMIN_TO_CODE),
+            gdf_ne.loc[
+                gdf_ne["admin"].isin(_OTHER_ADMIN_TO_CODE),
                 ["geometry", "name", "admin", "iso_a2"],
             ]
             .dissolve(by="admin", aggfunc={"name": list, "iso_a2": list})

--- a/epa_regions/__init__.py
+++ b/epa_regions/__init__.py
@@ -243,7 +243,7 @@ def get(
     #
 
     if states_only:
-        other = pd.DataFrame()
+        gdf = states
     else:
         other = (
             gdf.loc[
@@ -265,11 +265,8 @@ def get(
 
         other = other.drop(columns=["iso_a2"])
 
-    #
-    # Combine
-    #
-
-    gdf = pd.concat([states, other], ignore_index=True, sort=False)
+        # Combine
+        gdf = pd.concat([states, other], ignore_index=True, sort=False)
 
     #
     # Dissolve to EPA regions

--- a/epa_regions/__init__.py
+++ b/epa_regions/__init__.py
@@ -242,6 +242,7 @@ def get(
     # Other
     #
 
+    gdf: GeoDataFrame
     if states_only:
         gdf = states
     else:
@@ -266,7 +267,7 @@ def get(
         other = other.drop(columns=["iso_a2"])
 
         # Combine
-        gdf = pd.concat([states, other], ignore_index=True, sort=False)
+        gdf = pd.concat([states, other], ignore_index=True, sort=False)  # type: ignore[assignment]
 
     #
     # Dissolve to EPA regions

--- a/epa_regions/load.py
+++ b/epa_regions/load.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Final, Literal
 
 if TYPE_CHECKING:
     from geopandas import GeoDataFrame  # type: ignore[import-untyped]
 
+ENGINE: Literal["fiona", "pyogrio"]
 try:
     import pyogrio  # type: ignore[import-untyped]  # noqa: F401
 except ImportError:


### PR DESCRIPTION
with a recent pandas-stubs update, the `pd.concat` result was inferred to be DataFrame, not the GeoDataFrame that it (always) is